### PR TITLE
Updated syntax in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DPRINT_VERSION := 0.49.0 # renovate datasource=github-tags depName=dprint/dprint
+DPRINT_VERSION := 0.49.0 # renovate: datasource=github-tags depName=dprint/dprint
 DPRINT := ${CURDIR}/bin/dprint
 
 # https://github.com/oven-sh/bun/issues/7034


### PR DESCRIPTION
Corrected the syntax for specifying datasource and dependency name in the DPRINT_VERSION variable. This change ensures proper parsing by renovate bot.
