### PR TITLE
Updated Makefile to allow overriding DPRINT_VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DPRINT_VERSION := 0.49.0 # renovate: datasource=github-tags depName=dprint/dprint
+DPRINT_VERSION ?= 0.49.0 # renovate: datasource=github-tags depName=dprint/dprint
 DPRINT := ${CURDIR}/bin/dprint
 
 # https://github.com/oven-sh/bun/issues/7034


### PR DESCRIPTION
The DPRINT_VERSION in the Makefile has been modified to support overriding. This change provides more flexibility when specifying the version of dprint, allowing for easier testing and development with different versions.
